### PR TITLE
Add basic chat UI layout

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,17 +1,56 @@
 <template>
   <div class="app">
-    <h1>Vue Chat Codex</h1>
-    <HelloWorld msg="Welcome to your AI Chat app" />
+    <ChatSidebar
+      :conversations="conversations"
+      :selectedId="selectedId"
+      @select="selectConversation"
+    />
+    <ChatWindow
+      v-if="activeConversation"
+      :messages="activeConversation.messages"
+      @send="sendMessage"
+    />
   </div>
 </template>
 
 <script setup>
-import HelloWorld from './components/HelloWorld.vue'
+import { ref, computed } from 'vue'
+import ChatSidebar from './components/ChatSidebar.vue'
+import ChatWindow from './components/ChatWindow.vue'
+
+const conversations = ref([
+  {
+    id: 1,
+    title: 'Conversation 1',
+    messages: [
+      { text: 'Hello', sender: 'user' },
+      { text: 'Hi there!', sender: 'bot' }
+    ]
+  },
+  { id: 2, title: 'Conversation 2', messages: [] }
+])
+
+const selectedId = ref(conversations.value[0].id)
+
+const activeConversation = computed(() =>
+  conversations.value.find(c => c.id === selectedId.value)
+)
+
+function selectConversation(id) {
+  selectedId.value = id
+}
+
+function sendMessage(text) {
+  const conv = activeConversation.value
+  conv.messages.push({ text, sender: 'user' })
+  // Placeholder bot response
+  conv.messages.push({ text: '...', sender: 'bot' })
+}
 </script>
 
 <style>
 .app {
-  text-align: center;
-  padding: 2rem;
+  display: flex;
+  height: 100vh;
 }
 </style>

--- a/src/components/ChatSidebar.vue
+++ b/src/components/ChatSidebar.vue
@@ -1,0 +1,53 @@
+<template>
+  <div class="sidebar">
+    <h2>Conversations</h2>
+    <ul>
+      <li
+        v-for="conv in conversations"
+        :key="conv.id"
+        :class="{ active: conv.id === selectedId }"
+        @click="$emit('select', conv.id)"
+      >
+        {{ conv.title }}
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup>
+import { defineProps, defineEmits } from 'vue'
+
+const props = defineProps({
+  conversations: {
+    type: Array,
+    required: true
+  },
+  selectedId: {
+    type: Number,
+    required: true
+  }
+})
+
+defineEmits(['select'])
+</script>
+
+<style scoped>
+.sidebar {
+  width: 200px;
+  border-right: 1px solid #ccc;
+  padding: 1rem;
+}
+ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+li {
+  padding: 0.5rem;
+  cursor: pointer;
+}
+li.active {
+  background: #eee;
+  font-weight: bold;
+}
+</style>

--- a/src/components/ChatWindow.vue
+++ b/src/components/ChatWindow.vue
@@ -1,0 +1,69 @@
+<template>
+  <div class="chat-window">
+    <div class="messages">
+      <div
+        v-for="(msg, index) in messages"
+        :key="index"
+        :class="['message', msg.sender]"
+      >
+        {{ msg.text }}
+      </div>
+    </div>
+    <form class="input-area" @submit.prevent="handleSend">
+      <input v-model="text" placeholder="Type a message..." />
+      <button type="submit">Send</button>
+    </form>
+  </div>
+</template>
+
+<script setup>
+import { ref, defineProps, defineEmits } from 'vue'
+
+const props = defineProps({
+  messages: {
+    type: Array,
+    required: true
+  }
+})
+
+const emit = defineEmits(['send'])
+const text = ref('')
+
+function handleSend() {
+  if (!text.value.trim()) return
+  emit('send', text.value)
+  text.value = ''
+}
+</script>
+
+<style scoped>
+.chat-window {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+.messages {
+  flex: 1;
+  padding: 1rem;
+  overflow-y: auto;
+}
+.message {
+  margin-bottom: 0.5rem;
+}
+.message.user {
+  text-align: right;
+}
+.input-area {
+  display: flex;
+  padding: 1rem;
+  border-top: 1px solid #ccc;
+}
+.input-area input {
+  flex: 1;
+  padding: 0.5rem;
+}
+.input-area button {
+  margin-left: 0.5rem;
+}
+</style>


### PR DESCRIPTION
## Summary
- create `ChatSidebar` and `ChatWindow` components
- display conversations on the left and active chat on the right
- update `App.vue` to assemble the layout

## Testing
- `npm run build` *(fails: `vite` not found)*
- `npm install` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68528fc33f5c8328a838cb393e7c76fe